### PR TITLE
Avoid replacing the default Http Context

### DIFF
--- a/org.eclipse.osgitech.rest.servlet.whiteboard.tests/test.bndrun
+++ b/org.eclipse.osgitech.rest.servlet.whiteboard.tests/test.bndrun
@@ -78,6 +78,7 @@
 	org.osgi.service.jakartars;version='[2.0.0,2.0.1)',\
 	org.osgi.test.common;version='[1.2.1,1.2.2)',\
 	org.osgi.test.junit5;version='[1.2.1,1.2.2)',\
+	org.osgi.test.junit5.cm;version='[1.2.1,1.2.2)',\
 	org.osgi.util.converter;version='[1.0.9,1.0.10)',\
 	org.osgi.util.function;version='[1.2.0,1.2.1)',\
 	org.osgi.util.promise;version='[1.3.0,1.3.1)',\

--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/JerseyServiceRuntime.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/JerseyServiceRuntime.java
@@ -924,6 +924,7 @@ public class JerseyServiceRuntime<C extends Container> {
 		}
 		Application application = applicationProvider.getJakartarsApplication();
 		ResourceConfig config = ResourceConfig.forApplication(application);
+		config.setApplicationName(applicationProvider.getName());
 		final Map<String, Object> properties = new HashMap<String, Object>(config.getProperties());
 		properties.put(ServerProperties.RESOURCE_VALIDATION_IGNORE_ERRORS, Boolean.TRUE);
 		config.setProperties(properties);


### PR DESCRIPTION
The Servlet Whiteboard provider uses custom ServletContextHelper instances to provide isolation between REST applications. This is a good thing, but when no base was defined the default application was creating a ServletContextHelper which shadowed the default ServletContextHelper. This, in turn, causes unexpected changes in behaviour for people using the Servlet Whiteboard. To be good citizens we should use the default context for the default application when that is possible.