### PR TITLE
Refactoring to improve cohesion

### DIFF
--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/dto/DTOConverter.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/dto/DTOConverter.java
@@ -34,6 +34,7 @@ import org.eclipse.osgitech.rest.runtime.application.JerseyApplicationProvider;
 import org.eclipse.osgitech.rest.runtime.application.JerseyExtensionProvider;
 import org.eclipse.osgitech.rest.runtime.application.JerseyResourceProvider;
 import org.eclipse.osgitech.rest.runtime.application.feature.WhiteboardFeature;
+import org.glassfish.jersey.server.ResourceConfig;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.Constants;
 import org.osgi.framework.ServiceReference;
@@ -123,8 +124,13 @@ public class DTOConverter {
 		List<ExtensionDTO> edtos = new ArrayList<>();
 		
 //		Create the DTO for the static resources and extensions 
-		if(applicationProvider.getJakartarsApplication() instanceof JerseyApplication) {
-			Application sourceApp = ((JerseyApplication) applicationProvider.getJakartarsApplication()).getSourceApplication();
+		ResourceConfig resourceConfig = applicationProvider.getJakartarsApplication();
+		Application app = resourceConfig.getApplication();
+		if(app instanceof ResourceConfig) {
+			app = ((ResourceConfig) app).getApplication();
+		}
+		if(app instanceof JerseyApplication) {
+			Application sourceApp = ((JerseyApplication) app).getSourceApplication();
 			@SuppressWarnings("deprecation")
 			Set<Object> singletons = sourceApp.getSingletons();
 			Set<Class<?>> classes = sourceApp.getClasses();

--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/proxy/ApplicationProxyFactory.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/proxy/ApplicationProxyFactory.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2012 - 2023 Data In Motion and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors:
+ *     Tim Ward - implementation
+ */
+package org.eclipse.osgitech.rest.proxy;
+
+import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V11;
+import static org.objectweb.asm.Type.VOID_TYPE;
+import static org.objectweb.asm.Type.getDescriptor;
+import static org.objectweb.asm.Type.getInternalName;
+import static org.objectweb.asm.Type.getMethodDescriptor;
+import static org.objectweb.asm.Type.getType;
+
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.osgitech.rest.runtime.application.JerseyApplication;
+import org.eclipse.osgitech.rest.runtime.application.JerseyApplicationContentProvider;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+import jakarta.ws.rs.ApplicationPath;
+import jakarta.ws.rs.core.Application;
+
+/**
+ * This class is used to generate a proxy for an application service
+ * 
+ * The proxy will:
+ * 
+ * * Extend {@link JerseyApplication}
+ * * Copy the {@link ApplicationPath} annotation from the application
+ * * Have a single delegating constructor
+ * 
+ * 
+ * @author timothyjward
+ * @since 13 Jul 2023
+ */
+public class ApplicationProxyFactory {
+	
+	private static class DynamicSubClassLoader extends ClassLoader {
+
+		public DynamicSubClassLoader() {
+			super(JerseyApplication.class.getClassLoader());
+		}
+		
+		@SuppressWarnings("unchecked")
+		public Class<? extends JerseyApplication> getSubClass(byte[] bytes) {
+			return (Class<? extends JerseyApplication>) defineClass("org.eclipse.osgitech.rest.runtime.application.JerseyApplicationWithPath", bytes, 0, bytes.length);
+		}
+	}
+	
+	/**
+	 * Create a dynamic subclass instance
+	 * @param name - the application name
+	 * @param application - the source application, including the {@link ApplicationPath} annotation to copy
+	 * @param properties - the service properties
+	 * @param providers - the content providers for this application
+	 * @return
+	 */
+	public static JerseyApplication createDynamicSubclass(String name, Application application, Map<String, Object> properties,
+			List<JerseyApplicationContentProvider> providers) {
+
+		ApplicationPath pathInfo = application.getClass().getAnnotation(ApplicationPath.class);
+		String superName = getInternalName(JerseyApplication.class);
+
+		// Write the class header, with JerseyApplication as the superclass
+		ClassWriter writer = new ClassWriter(COMPUTE_FRAMES);
+		writer.visit(V11, ACC_PUBLIC, "org/eclipse/osgitech/rest/runtime/application/JerseyApplicationWithPath", null, 
+				superName, null);
+		// Write the application path annotation
+		AnnotationVisitor av = writer.visitAnnotation(getDescriptor(ApplicationPath.class), true);
+		av.visit("value", pathInfo.value());
+		av.visitEnd();
+		
+		// Write a constructor which directly calls super and nothing else
+		String constructorDescriptor = getMethodDescriptor(VOID_TYPE, getType(String.class), 
+				getType(Application.class), getType(Map.class), getType(List.class));
+		
+		MethodVisitor mv = writer.visitMethod(ACC_PUBLIC, "<init>", constructorDescriptor, null, null);
+		mv.visitCode();
+		mv.visitVarInsn(Opcodes.ALOAD, 0);
+		mv.visitVarInsn(Opcodes.ALOAD, 1);
+		mv.visitVarInsn(Opcodes.ALOAD, 2);
+		mv.visitVarInsn(Opcodes.ALOAD, 3);
+		mv.visitVarInsn(Opcodes.ALOAD, 4);
+		mv.visitMethodInsn(Opcodes.INVOKESPECIAL, superName, "<init>", constructorDescriptor, false);
+		mv.visitInsn(RETURN);
+		mv.visitMaxs(4, 4);
+		mv.visitEnd();
+		writer.visitEnd();
+		
+		DynamicSubClassLoader loader = new DynamicSubClassLoader();
+		Class<? extends JerseyApplication> clazz = loader.getSubClass(writer.toByteArray());
+		try {
+			return clazz.getConstructor(String.class, Application.class, Map.class, List.class).newInstance(name, application, properties, providers);
+		} catch (Exception e) {
+			throw new IllegalArgumentException(e);
+		}
+	}
+	
+}

--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/WhiteboardServletContainer.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/WhiteboardServletContainer.java
@@ -20,17 +20,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import org.eclipse.osgitech.rest.annotations.RequireJerseyServlet;
-import org.eclipse.osgitech.rest.binder.PromiseResponseHandlerBinder;
 import org.eclipse.osgitech.rest.provider.jakartars.RuntimeDelegateService;
-import org.glassfish.hk2.api.ServiceLocator;
-import org.glassfish.hk2.api.ServiceLocatorFactory;
-import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
 import org.glassfish.jersey.server.ApplicationHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.servlet.ServletContainer;
-import org.glassfish.jersey.servlet.ServletProperties;
-import org.glassfish.jersey.servlet.async.AsyncContextDelegateProviderImpl;
-import org.glassfish.jersey.servlet.init.FilterUrlMappingsProviderImpl;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -45,9 +38,6 @@ import jakarta.servlet.http.HttpServletResponse;
 @RequireJerseyServlet
 public class WhiteboardServletContainer extends ServletContainer {
 
-	/** SERVICE_LOCATOR_PREFIX */
-	private static final String SERVICE_LOCATOR_PREFIX = "JakartaRESTJerseyWhiteboard-";
-
 	/**
 	 * 
 	 */
@@ -58,16 +48,8 @@ public class WhiteboardServletContainer extends ServletContainer {
 	private final AtomicBoolean initialized = new AtomicBoolean();
 	private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-	private final ServiceLocator locator;
-
 	public WhiteboardServletContainer(ResourceConfig config) {
 		initialConfig = config;
-		
-		// Ensure that promise types can be returned by resource methods
-		locator = ServiceLocatorFactory.getInstance()
-			.create(SERVICE_LOCATOR_PREFIX + System.identityHashCode(this));
-		ServiceLocatorUtilities.bind(locator, new PromiseResponseHandlerBinder());
-		ServiceLocatorUtilities.addClasses(locator, AsyncContextDelegateProviderImpl.class, FilterUrlMappingsProviderImpl.class);
 	}
 
 	/* (non-Javadoc)
@@ -83,7 +65,6 @@ public class WhiteboardServletContainer extends ServletContainer {
 			try {
 				Thread.currentThread().setContextClassLoader(RuntimeDelegateService.class.getClassLoader());
 				
-				getServletContext().setAttribute(ServletProperties.SERVICE_LOCATOR, locator);
 				super.init();
 				// we have to wait until the injection manager is available on first start
 				Future<?> future = Executors.newSingleThreadExecutor().submit(()->{
@@ -189,6 +170,5 @@ public class WhiteboardServletContainer extends ServletContainer {
 	}
 
 	public void dispose() {
-		locator.shutdown();
 	}
 }

--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/application/JerseyApplication.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/application/JerseyApplication.java
@@ -13,15 +13,21 @@
  */
 package org.eclipse.osgitech.rest.runtime.application;
 
+import static java.util.stream.Collectors.toUnmodifiableSet;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import org.eclipse.osgitech.rest.binder.PromiseResponseHandlerBinder;
 import org.eclipse.osgitech.rest.binder.PrototypeServiceBinder;
 import org.eclipse.osgitech.rest.factories.InjectableFactory;
 import org.eclipse.osgitech.rest.factories.JerseyResourceInstanceFactory;
@@ -29,6 +35,8 @@ import org.eclipse.osgitech.rest.runtime.application.feature.WhiteboardFeature;
 import org.glassfish.jersey.internal.inject.InjectionManager;
 import org.glassfish.jersey.server.spi.AbstractContainerLifecycleListener;
 import org.glassfish.jersey.server.spi.Container;
+import org.glassfish.jersey.servlet.async.AsyncContextDelegateProviderImpl;
+import org.glassfish.jersey.servlet.init.FilterUrlMappingsProviderImpl;
 import org.osgi.framework.ServiceObjects;
 import org.osgi.service.jakartars.whiteboard.JakartarsWhiteboardConstants;
 
@@ -94,10 +102,10 @@ public class JerseyApplication extends Application {
 	 */
 	@Override
 	public Set<Class<?>> getClasses() {
-		Set<Class<?>> resutlClasses = new HashSet<>();
-		resutlClasses.addAll(classes.values());
-		resutlClasses.addAll(sourceApplication.getClasses());
-		return Collections.unmodifiableSet(resutlClasses);
+		return Stream.of(classes.values().stream(), sourceApplication.getClasses().stream(),
+				Stream.of(PromiseResponseHandlerBinder.class, AsyncContextDelegateProviderImpl.class, FilterUrlMappingsProviderImpl.class))
+				.flatMap(Function.identity())
+				.collect(toUnmodifiableSet());
 	}
 
 	/* 

--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/application/feature/WhiteboardFeature.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/application/feature/WhiteboardFeature.java
@@ -78,12 +78,4 @@ public class WhiteboardFeature implements Feature{
 		extensionInstanceTrackingMap.clear();
 		extensions.clear();
 	}
-
-	public void dispose(JerseyExtensionProvider extProvider) {
-		JerseyExtension je = extensionInstanceTrackingMap.remove(extProvider);
-
-		if(je != null) {
-			je.dispose();
-		}
-	}
 }


### PR DESCRIPTION
There are several portions of the codebase that share responsibility for registering the custom types that we need for the whiteboard to work correctly. This series of commits centralises these registrations in the JerseyApplication, simplifying the JerseyServiceRuntime and the WhiteboardServletContainer. The commit also makes the JerseyApplication immutable once created, dramatically simplifying the lifecycle of the objects.