### PR TITLE
Avoid exceptions when extension objects cannot be retrieved

### DIFF
--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/JerseyServiceRuntime.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/JerseyServiceRuntime.java
@@ -233,7 +233,7 @@ public class JerseyServiceRuntime<C extends Container> {
 				@Override
 				public void removedService(ServiceReference<Object> reference, ServiceReference<?> service) {
 					JerseyExtensionProvider provider = new JerseyExtensionProvider(
-							context.getServiceObjects(reference), getServiceProps(reference));
+							null, getServiceProps(reference));
 					clearMap(extensionMap, provider);
 				}
 				

--- a/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/application/feature/WhiteboardFeature.java
+++ b/org.eclipse.osgitech.rest/src/main/java/org/eclipse/osgitech/rest/runtime/application/feature/WhiteboardFeature.java
@@ -56,12 +56,14 @@ public class WhiteboardFeature implements Feature{
 
 			JerseyExtension je = extension.getExtension(context);
 
-			extensionInstanceTrackingMap.put(extension, je);
-			Map<Class<?>,Integer> contractPriorities = je.getContractPriorities();
-			if (contractPriorities.isEmpty()) {
-				context.register(je.getExtensionObject(), priority.getAndIncrement());
-			} else {
-				context.register(je.getExtensionObject(), je.getContractPriorities());
+			if(je != null) {
+				extensionInstanceTrackingMap.put(extension, je);
+				Map<Class<?>,Integer> contractPriorities = je.getContractPriorities();
+				if (contractPriorities.isEmpty()) {
+					context.register(je.getExtensionObject(), priority.getAndIncrement());
+				} else {
+					context.register(je.getExtensionObject(), je.getContractPriorities());
+				}
 			}
 		});
 		return true;


### PR DESCRIPTION
Sometimes services will have been unregistered while we are still setting up a whiteboard application. In those cases the service may disappear while we are starting and can cause initialisation failures. We must protect against errors in those cases.