### PR TITLE
Further work on Generics support

### DIFF
--- a/org.eclipse.osgitech.rest/src/test/java/org/eclipse/osgitech/rest/proxy/ExtensionProxyTest.java
+++ b/org.eclipse.osgitech.rest/src/test/java/org/eclipse/osgitech/rest/proxy/ExtensionProxyTest.java
@@ -323,6 +323,91 @@ public class ExtensionProxyTest {
 				.getContext(String.class));
 		
 	}
+
+	@Test
+	public void testRedirectsParameterContext() throws Exception {
+		
+		ContextResolver<?> cr = new RedirectsParameterContext<>();
+		
+		Class<?> proxyClazz = pcl.define("test.ContextResolver", cr, 
+				singletonList(ContextResolver.class));
+		
+		TypeVariable<?>[] typeParameters = proxyClazz.getTypeParameters();
+		assertEquals(1, typeParameters.length);
+		assertTrue(TypeVariable.class.isInstance(typeParameters[0]));
+		assertEquals("R", typeParameters[0].toString());
+		
+		assertTrue(ContextResolver.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(1, genericInterfaces.length);
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(ContextResolver.class, pt.getRawType());
+		assertTrue(TypeVariable.class.isInstance(pt.getActualTypeArguments()[0]));
+		assertEquals("R", pt.getActualTypeArguments()[0].toString());
+		
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> cr);
+		
+		assertEquals("", ((ContextResolver<?>)instance)
+				.getContext(String.class));
+		
+	}
+	
+	@Test
+	public void testChildExtendsRedirectedParameterContext() throws Exception {
+		
+		ContextResolver<Double> cr = new ChildExtendsRedirectedParameterContext();
+		
+		Class<?> proxyClazz = pcl.define("test.ContextResolver", cr, 
+				singletonList(ContextResolver.class));
+		TypeVariable<?>[] typeParameters = proxyClazz.getTypeParameters();
+		assertEquals(0, typeParameters.length);
+		
+		assertTrue(ContextResolver.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(1, genericInterfaces.length);
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(ContextResolver.class, pt.getRawType());
+		assertEquals(Double.class, pt.getActualTypeArguments()[0]);
+		
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> cr);
+		
+		assertEquals(42.0d, ((ContextResolver<?>)instance)
+				.getContext(String.class));
+		
+	}
+	@Test
+	public void testChildExtraExtendsRedirectedParameterContext() throws Exception {
+		
+		ContextResolver<List<Double>> cr = new ChildExtraExtendsRedirectedParameterContext();
+		
+		Class<?> proxyClazz = pcl.define("test.ContextResolver", cr, 
+				singletonList(ContextResolver.class));
+		assertTrue(ContextResolver.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(1, genericInterfaces.length);
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(ContextResolver.class, pt.getRawType());
+		assertTrue(ParameterizedType.class.isInstance(pt.getActualTypeArguments()[0]));
+		assertEquals("java.util.List<java.lang.Double>", pt.getActualTypeArguments()[0].getTypeName());
+		
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> cr);
+		
+		assertEquals(Collections.singletonList(17.0d), ((ContextResolver<?>)instance)
+				.getContext(String.class));
+		
+	}
 	
 	@SuppressWarnings("unchecked")
 	@Test
@@ -491,6 +576,28 @@ public class ExtensionProxyTest {
 		@Override
 		public List<? super Integer> getContext(Class<?> type) {
 			return new ArrayList<>();
+		}
+		
+	}
+	
+	public static class RedirectsParameterContext<R> extends ParameterContext<R> {
+		
+	}
+	
+	public static class ChildExtendsRedirectedParameterContext extends RedirectsParameterContext<Double> {
+		
+		@Override
+		public Double getContext(Class<?> type) {
+			return 42.0d;
+		}
+		
+	}
+
+	public static class ChildExtraExtendsRedirectedParameterContext extends RedirectsParameterContext<List<Double>> {
+		
+		@Override
+		public List<Double> getContext(Class<?> type) {
+			return Collections.singletonList(17.0d);
 		}
 		
 	}


### PR DESCRIPTION
This PR relates to issue #39 which while technically "fixed" (the original problem no longer occurs in the main branch) was still possible to trigger with suitably complex generics.

I identified a missing test case where a Type Variable changes name in the generics declaration of an intermediate super class, and also where the Type Variable use is nested inside another generic declaration. Once added these tests showed up some further weaknesses which I have attempted to fix by establishing a context mapping of contract interface to implementing type and type to super type. This constrains the search through the type information and ensures that we only match type information that is relevant in the current context.

Please comment with any further test cases.
@fipro78 @maho7791 @juergen-albert 