### PR TITLE
Impl #44 - Add CRaC support

### DIFF
--- a/org.eclipse.osgitech.rest.jetty/pom.xml
+++ b/org.eclipse.osgitech.rest.jetty/pom.xml
@@ -74,6 +74,10 @@
 			<groupId>org.apache.felix</groupId>
 			<artifactId>org.apache.felix.http.jetty</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.crac</groupId>
+			<artifactId>crac</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -114,6 +118,27 @@
 								</artifactItem>
 							</artifactItems>
 						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				 <groupId>biz.aQute.bnd</groupId>
+				 <artifactId>bnd-maven-plugin</artifactId>
+				 <extensions>true</extensions>
+				 <executions>
+					<execution>
+						<id>jar</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<bnd><![CDATA[
+							Import-Package: org.crac.*;resolution:=optional, *
+							-noextraheaders: true
+							-noimportjava: true
+							-fixupmessages: The JAR is empty:
+							]]></bnd>
+						 </configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/org.eclipse.osgitech.rest.jetty/src/main/java/org/eclipse/osgitech/rest/jetty/JettyCracResource.java
+++ b/org.eclipse.osgitech.rest.jetty/src/main/java/org/eclipse/osgitech/rest/jetty/JettyCracResource.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2024 Dirk Fauth and others.
+ * All rights reserved. 
+ * 
+ * This program and the accompanying materials are made available under the terms of the 
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v20.html
+ * 
+ * Contributors:
+ *     Dirk Fauth - initial API and implementation
+ */
+package org.eclipse.osgitech.rest.jetty;
+
+import java.util.Arrays;
+
+import org.crac.Context;
+import org.crac.Core;
+import org.crac.Resource;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.LifeCycle;
+
+/**
+ * This class is used to add CRaC support to the jetty bundle by using the
+ * <code>org.crac</code> API. It adapts the examples and best practices from the
+ * CRaC documentation and the examples.
+ * 
+ * @see <a href="https://github.com/CRaC/org.crac">`org.crac` API</a>
+ * @see <a href=
+ *      "https://docs.azul.com/core/crac/crac-tips-tricks#implementing-resource-as-inner-class">Implementing
+ *      Resource as Inner Class</a>
+ * @see <a href=
+ *      "https://github.com/CRaC/docs/blob/master/STEP-BY-STEP.md">Step-by-step
+ *      CRaC support for a Jetty app</a>
+ * @see <a href=
+ *      "https://github.com/CRaC/example-jetty/blob/master/src/main/java/com/example/App.java">CRaC
+ *      example-jetty</a>
+ */
+public class JettyCracResource {
+
+	// the org.crac.Resource is implemented as an inner class and kept as a strong
+	// reference to avoid that it is garbage collected after the registration.
+	private Resource cracHandler;
+
+	public JettyCracResource(JettyBackedWhiteboardComponent jettyComponent) {
+		cracHandler = new Resource() {
+			@Override
+			public void beforeCheckpoint(Context<? extends Resource> context) {
+				Server jettyServer = jettyComponent.getJettyServer();
+				if (jettyServer != null && !jettyServer.isStopped()) {
+					// Stop the connectors only and keep the expensive application running
+					Arrays.asList(jettyServer.getConnectors()).forEach(c -> LifeCycle.stop(c));
+				}
+			}
+
+			@Override
+			public void afterRestore(Context<? extends Resource> context) {
+				Server jettyServer = jettyComponent.getJettyServer();
+				if (jettyServer != null && !jettyServer.isStopped()) {
+					Arrays.asList(jettyServer.getConnectors()).forEach(c -> LifeCycle.start(c));
+				}
+			}
+		};
+		Core.getGlobalContext().register(cracHandler);
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
 		<asm.version>9.5</asm.version>
 		<jackson.version>2.15.2</jackson.version>
 		<parsson.version>1.1.5</parsson.version>
+		<crac.version>1.5.0</crac.version>
 	</properties>
 
 	<modules>
@@ -464,6 +465,12 @@
 				<artifactId>biz.aQute.bnd.annotation</artifactId>
 				<version>6.4.0</version>
 			 </dependency>
+			 <dependency>
+				<groupId>org.crac</groupId>
+				<artifactId>crac</artifactId>
+				<version>${crac.version}</version>
+				<scope>provided</scope>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
This PR adds CRaC support to the jetty bundle by using the [`org.crac` API](https://github.com/CRaC/org.crac).

It adapts 
- [Implementing Resource as Inner Class](https://docs.azul.com/core/crac/crac-tips-tricks#implementing-resource-as-inner-class) 
- [Step-by-step CRaC support for a Jetty app](https://github.com/CRaC/docs/blob/master/STEP-BY-STEP.md)
- [CRaC example-jetty](https://github.com/CRaC/example-jetty/blob/master/src/main/java/com/example/App.java)

@AntonKozlov
Could you also have a look and provide some comment, if my assumption that the usage of `org.crac` API is without a risk here?