### PR TITLE
[generics] Restore deleted tests and improve consistency of access

### DIFF
--- a/org.eclipse.osgitech.rest/src/test/java/org/eclipse/osgitech/rest/proxy/ExtensionProxyTest.java
+++ b/org.eclipse.osgitech.rest/src/test/java/org/eclipse/osgitech/rest/proxy/ExtensionProxyTest.java
@@ -496,6 +496,100 @@ public class ExtensionProxyTest {
 
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testMultiInterfaceGenericComplex() throws Exception {
+		
+		TestMultiInterfaceGenericComplex<Object, Object> mi = new TestMultiInterfaceGenericComplex<>();
+		
+		// Deliberately re-order the interfaces relative to the implements clause
+		Class<?> proxyClazz = pcl.define("test.MultiInterfaceGenericComplex", mi, 
+				Arrays.asList(MessageBodyWriter.class, MessageBodyReader.class));
+		
+		assertTrue(MessageBodyReader.class.isAssignableFrom(proxyClazz));
+		assertTrue(MessageBodyWriter.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(2, genericInterfaces.length);
+		
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(MessageBodyWriter.class, pt.getRawType());
+		TypeVariable<?> tv = (TypeVariable) pt.getActualTypeArguments()[0];
+		assertEquals("W", tv.getName());
+		assertArrayEquals(new Type[] {Object.class}, tv.getBounds());
+		
+		assertTrue(genericInterfaces[1] instanceof ParameterizedType);
+		pt = (ParameterizedType) genericInterfaces[1];
+		assertEquals(MessageBodyReader.class, pt.getRawType());
+		tv = (TypeVariable) pt.getActualTypeArguments()[0];
+		assertEquals("R", tv.getName());
+		assertArrayEquals(new Type[] {Object.class}, tv.getBounds());
+		
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> mi);
+		
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		((MessageBodyWriter) instance).writeTo("ignore me", Object.class, null, null, null, null, baos);
+		
+		assertArrayEquals(new byte[]{0x42}, baos.toByteArray());
+		
+		
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		
+		
+		assertEquals("tada", ((MessageBodyReader) instance).readFrom(Object.class, null, null, null, null, bais));
+		
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	public void testMultiInterfaceGenericComplexTwo() throws Exception {
+		
+		TestMultiInterfaceGenericComplexTwo<Integer, String> mi = new TestMultiInterfaceGenericComplexTwo<>();
+		
+		// Deliberately re-order the interfaces relative to the implements clause
+		Class<?> proxyClazz = pcl.define("test.MultiInterfaceGenericComplexTwo", mi, 
+				Arrays.asList(MessageBodyWriter.class, MessageBodyReader.class));
+		
+		assertTrue(MessageBodyReader.class.isAssignableFrom(proxyClazz));
+		assertTrue(MessageBodyWriter.class.isAssignableFrom(proxyClazz));
+		Type[] genericInterfaces = proxyClazz.getGenericInterfaces();
+		
+		assertEquals(2, genericInterfaces.length);
+		
+		assertTrue(genericInterfaces[0] instanceof ParameterizedType);
+		ParameterizedType pt = (ParameterizedType) genericInterfaces[0];
+		assertEquals(MessageBodyWriter.class, pt.getRawType());
+		TypeVariable<?> tv = (TypeVariable) pt.getActualTypeArguments()[0];
+		assertEquals("W", tv.getName());
+		assertArrayEquals(new Type[] {CharSequence.class}, tv.getBounds());
+		
+		assertTrue(genericInterfaces[1] instanceof ParameterizedType);
+		pt = (ParameterizedType) genericInterfaces[1];
+		assertEquals(MessageBodyReader.class, pt.getRawType());
+		tv = (TypeVariable) pt.getActualTypeArguments()[0];
+		assertEquals("R", tv.getName());
+		assertArrayEquals(new Type[] {Number.class}, tv.getBounds());
+		
+		Object instance = proxyClazz.getConstructor(Supplier.class)
+				.newInstance((Supplier<?>) () -> mi);
+		
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		((MessageBodyWriter) instance).writeTo("banana", CharSequence.class, null, null, null, null, baos);
+		
+		// 4 characters, "anan" 
+		assertArrayEquals(new byte[]{0,4,97,110,97,110}, baos.toByteArray());
+		
+		
+		ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
+		
+		
+		assertEquals(17, ((MessageBodyReader) instance).readFrom(Number.class, null, null, null, null, bais));
+		
+	}
+
 	@Test
 	public void testMultiInterfaceMapperJerseyStyle() throws Exception {
 


### PR DESCRIPTION
The latest commit removed some tests which need to be restored. It also made some visitor usage inconsistent, so we now respect the return value of visitTypeParameter everywhere